### PR TITLE
Detect pickles with shutil imports

### DIFF
--- a/lib/constants.py
+++ b/lib/constants.py
@@ -128,6 +128,7 @@ UNSAFE_STRINGS: FrozenSet[str] = frozenset([
     "requests",
     "runpy",
     "safer_pickle_hook",
+    "shutil",
     "socket",
     "ssl",
     "stdin",


### PR DESCRIPTION
See #1. 

The malicious pickle from the issue is now correctly classified as _unsafe_:

```
$ uv run --with-requirements requirements.txt -- safer_pickle_cli.py --directory tests
[
  {
    "status": "success",
    "filename": "tests/shutil.pkl",
    "classification": "unsafe",
    "justification": "Found malicious results: shutil.copy"
  }
]
```