### PR TITLE
propagate check_magic_bytes through bz2/lzma/gzip archive scans

### DIFF
--- a/saferpickle.py
+++ b/saferpickle.py
@@ -1122,6 +1122,7 @@ def _extract_and_scan_archive(
           force_scan=force_scan,
           recursion_depth=recursion_depth + 1,
           fail_fast=fail_fast,
+          check_magic_bytes=check_magic_bytes,
       )
       _merge_scores(all_scores, scores)
 
@@ -1132,6 +1133,7 @@ def _extract_and_scan_archive(
           force_scan=force_scan,
           recursion_depth=recursion_depth + 1,
           fail_fast=fail_fast,
+          check_magic_bytes=check_magic_bytes,
       )
       _merge_scores(all_scores, scores)
 
@@ -1142,6 +1144,7 @@ def _extract_and_scan_archive(
           force_scan=force_scan,
           recursion_depth=recursion_depth + 1,
           fail_fast=fail_fast,
+          check_magic_bytes=check_magic_bytes,
       )
       _merge_scores(all_scores, scores)
 


### PR DESCRIPTION
`_extract_and_scan_archive` forwards `check_magic_bytes` to the recursive `security_scan` call on the zip and tar branches, but the bz2, lzma and gzip branches leave it off, so those three fall back to the default and re-enable the fast-path rejection the caller explicitly asked to turn off. A protocol-0 pickle is all ASCII, so prefixing one with a `CODE_KEYWORDS` string like `use ` gets it fast-path rejected as source code; scanning those bytes raw with `check_magic_bytes=False` scores `unsafe: 3` and the same bytes in a zip also score `unsafe: 3`, but gzip, bz2 or xz wrapping drops them to `unsafe: 0`, so recompressing is enough to hide a payload from a caller who opted into the stricter scan. Passing the flag through at the three sites lines the compressed branches up with the raw and zip paths, and I checked benign and malicious pickles at protocols 0 and 5 to confirm the default `check_magic_bytes=True` behavior is unchanged.