### PR TITLE
scan zip members by infolist instead of name

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -313,9 +313,9 @@ def extract_zip_contents(
       io.BytesIO(file_bytes) if isinstance(file_bytes, bytes) else file_bytes
   )
   with zipfile.ZipFile(stream) as zf:
-    for name in zf.namelist():
-      with zf.open(name) as f:
-        yield name, f
+    for info in zf.infolist():
+      with zf.open(info) as f:
+        yield info.filename, f
 
 
 def is_bz2_bytes(file_bytes: bytes | BinaryIO) -> bool:

--- a/saferpickle.py
+++ b/saferpickle.py
@@ -1087,7 +1087,8 @@ def _extract_and_scan_archive(
     if archive_type == "zip":
       try:
         with zipfile.ZipFile(io.BytesIO(data)) as zf:
-          for name in zf.namelist():
+          for info in zf.infolist():
+            name = info.filename
             if ".." in name or name.startswith("/"):
               # Zip slip detection
               logging.warning("Zip slip detected: %s", name)
@@ -1097,7 +1098,7 @@ def _extract_and_scan_archive(
                   "unknown": 0,
               }  # Return early
 
-            with zf.open(name) as f:
+            with zf.open(info) as f:
               content = f.read()
               scores = security_scan(
                   content,


### PR DESCRIPTION
The zip branch of `_extract_and_scan_archive` walks `zf.namelist()` and reopens each member with `zf.open(name)`, but zipfile resolves a name through `NameToInfo`, which only remembers the last entry carrying that name. So in an archive with two members called `model.pkl` the second one gets read twice and the first one is never scanned: a zip holding a malicious pickle first and a benign dict second comes back `unsafe: 0`, while that same pickle alone in a zip comes back `unsafe: 3`. Opening the `ZipInfo` objects from `infolist()` visits every member exactly once regardless of duplicate names, and `utils.extract_zip_contents` enumerates the same way so it gets the same treatment.