### PR TITLE
match genops operands case-sensitively against unsafe strings

### DIFF
--- a/saferpickle.py
+++ b/saferpickle.py
@@ -565,19 +565,23 @@ def _categorize_genops(
   unknown_results: Set[str] = set()
 
   for line in filtered_output:
-    line_in_lowercase = line.lower()
+    # Match against the operand as-is. Python module and attribute names are
+    # case-sensitive and the string lists / patterns are case-sensitive too, so
+    # lowercasing here hides the mixed-case unsafe names (VirtualAlloc,
+    # CreateThread, RtlMoveMemory, WaitForSingleObject, Crypto, ...) that a
+    # global can carry.
     unsafe_match = any(
-        unsafe_string in line_in_lowercase
+        unsafe_string in line
         for unsafe_string in constants.UNSAFE_STRINGS
-    ) and re.findall(utils.unsafe_pattern, line_in_lowercase)
+    ) and re.findall(utils.unsafe_pattern, line)
     safe_match = any(
-        safe_string in line_in_lowercase
+        safe_string in line
         for safe_string in constants.SAFE_STRINGS
-    ) and re.findall(utils.safe_pattern, line_in_lowercase)
+    ) and re.findall(utils.safe_pattern, line)
     suspicious_match = any(
-        suspicious_string in line_in_lowercase
+        suspicious_string in line
         for suspicious_string in constants.SUSPICIOUS_STRINGS
-    ) and re.findall(utils.suspicious_pattern, line_in_lowercase)
+    ) and re.findall(utils.suspicious_pattern, line)
 
     if unsafe_match:
       for match in unsafe_match:
@@ -590,7 +594,7 @@ def _categorize_genops(
         suspicious_results.add(match)
     else:
       # Only check for unknown if no other categories matched
-      unknown_match = re.findall(utils.unknown_pattern, line_in_lowercase)
+      unknown_match = re.findall(utils.unknown_pattern, line)
       if unknown_match:
         for match in unknown_match:
           unknown_results.add(match)


### PR DESCRIPTION
_categorize_genops lowercases each operand before matching it, but UNSAFE_STRINGS and the compiled patterns are case-sensitive, so the mixed-case entries (VirtualAlloc, CreateThread, RtlMoveMemory, WaitForSingleObject, Crypto, cProfile, code.InteractiveConsole) never match. A pickle that resolves a global whose name is one of those scores unsafe=0 in the genops scan, and because picklemagic cannot tie the bare name to a known module the whole scan comes back clean on those classic ctypes shellcode primitives. Match the operand as-is, the way strict_security_scan and classify_class_name already do.